### PR TITLE
Note any insignficant difference and lower the threshold.

### DIFF
--- a/src/get-message.js
+++ b/src/get-message.js
@@ -60,12 +60,12 @@ module.exports = (fromBundles, toBundles) => {
 	}).filter(b => b.previous);
 
 	// Message if no bundle sizes have changes at all.
-	const unequalComparisons = bundleComparisons.filter(c => {
+	const noBundleSizeChanges = bundleComparisons.every(c => {
 		const rawDiff = getSizeDiff(c.current, c.previous);
-		return Math.abs(rawDiff) !== 0;
+		return Math.abs(rawDiff) === 0;
 	});
 
-	if (unequalComparisons.length === 0) {
+	if (noBundleSizeChanges) {
 		return 'No bundle size differences found.';
 	}
 

--- a/src/get-message.js
+++ b/src/get-message.js
@@ -1,42 +1,97 @@
 'use strict';
 
+// The size (kb) to count as a significant bundles size change.
+const threshold = 0.2;
+
+/**
+ * Get the bundle size difference between two bundles.
+ * @param {Object} current - The more recent bundle for comparison.
+ * @param {Object} previous - The bundle which pre-dates the current bundle.
+* @return {String}
+ */
 function getSizeDiff(current, previous) {
 	return ((current - previous) / 1024).toFixed(2);
 }
 
-function getMessage(current, previous, brand) {
+/**
+ * Get a message to describe the bundle size difference between two sets of bundles.
+ * @param {Object} current - The more recent bundle for comparison.
+ * @param {Object} previous - The bundle which pre-dates the current bundle.
+ * @return {String}
+ */
+function getBundleComparisonMessage(current, previous) {
 	const gzipDiff = getSizeDiff(current.sizes.gzip, previous.sizes.gzip);
 	const rawDiff = getSizeDiff(current.sizes.raw, previous.sizes.raw);
 
-	if (Math.abs(rawDiff) < 0.5) {
-		return ''; // no significant chnage, -0.5kb
+	// Use the current brand in the key in case the previous version is unbranded,
+	// but the current version has just added brand support.
+	const key = `${current.language}${current.brand ? `, ${current.brand}` : ''}`;
+
+	if (Math.abs(rawDiff) === 0) {
+		return `${key}: no difference.`;
 	}
 
-	const key = `${previous.language}${brand ? `, ${brand}` : ''}:`;
+	if (Math.abs(rawDiff) < threshold) {
+		return `${key}: no significant difference.`;
+	}
+
 	const raw = `${Math.abs(rawDiff)}kb ${rawDiff < 0 ? 'decrease' : 'increase'}`;
 	const gzip = `(${gzipDiff}kb/gzip)`;
-
-	return [
-		key,
-		raw,
-		gzip
-	].filter(m => m).join(' ');
+	return `${key}: ${raw} ${gzip}`;
 }
 
 module.exports = (fromBundles, toBundles) => {
-	let message = '';
-	toBundles.forEach(current => {
-		const brand = current.brand;
+	// Find a matching bundle from a previous version to compare with the
+	// current bundle. Compare bundles of the same language and brand, or
+	// unbranded versions against the master brand of a branded version.
+	const bundleComparisons = toBundles.map(current => {
 		const previous = fromBundles.find(previous => (
 			previous.language === current.language &&
 			(previous.brand === current.brand || (previous.brand === null && current.brand === 'master'))
 		));
-		if (previous) {
-			const part = getMessage(current, previous, brand);
-			if (part) {
-				message += (message ? '\n' + part : part);
-			}
-		}
+		return {
+			current,
+			previous
+		};
+	}).filter(b => b.previous);
+
+	// Message if no bundle sizes have changes at all.
+	const unequalComparisons = bundleComparisons.filter(c => {
+		const rawDiff = getSizeDiff(c.current.sizes.raw, c.previous.sizes.raw);
+		return Math.abs(rawDiff) !== 0;
 	});
-	return message || 'No bundle size difference found.';
+
+	if (unequalComparisons.length === 0) {
+		return 'No bundle size differences found.';
+	}
+
+	// Message if only small bundle size differences, which are not significant.
+	const significantComparisons = bundleComparisons.filter(c => {
+		const rawDiff = getSizeDiff(c.current.sizes.raw, c.previous.sizes.raw);
+		return Math.abs(rawDiff) > threshold;
+	});
+
+	if (significantComparisons.length === 0) {
+		return 'No significant bundle size differences found.';
+	}
+
+	// Message when at least some bundles have significantly changed.
+	// Only get messages for bundles which do have a significant difference.
+	let message = significantComparisons.map(c => {
+		return getBundleComparisonMessage(c.current, c.previous);
+	}).join('\n');
+
+	// But note the bundles with an insignificant difference.
+	const insignificantComparisons = bundleComparisons.filter(c =>
+		!significantComparisons.includes(c)
+	);
+	if (insignificantComparisons.length !== 0) {
+		message = `${message}\n` +
+			'An insignificant difference was found for: ' +
+			insignificantComparisons.map(c =>
+				`${c.current.language}${c.current.brand ? ` (${c.current.brand})` : ''}`
+			).join(', ');
+	}
+
+	return message;
 };

--- a/src/get-message.js
+++ b/src/get-message.js
@@ -4,7 +4,7 @@
 const threshold = 0.2;
 
 /**
- * Get the bundle size difference between two bundles.
+ * Get the bundle size difference between two bundles in KB.
  * @param {Object} current - The more recent bundle for comparison.
  * @param {Object} previous - The bundle which pre-dates the current bundle.
 * @return {String}

--- a/src/get-message.js
+++ b/src/get-message.js
@@ -87,7 +87,7 @@ module.exports = (fromBundles, toBundles) => {
 	);
 	if (insignificantComparisons.length !== 0) {
 		message = `${message}\n` +
-			'An insignificant difference was found for: ' +
+			'An insignificant difference was also found for: ' +
 			insignificantComparisons.map(c =>
 				`${c.current.language}${c.current.brand ? ` (${c.current.brand})` : ''}`
 			).join(', ');

--- a/src/get-message.js
+++ b/src/get-message.js
@@ -7,10 +7,14 @@ const threshold = 0.2;
  * Get the bundle size difference between two bundles in KB.
  * @param {Object} current - The more recent bundle for comparison.
  * @param {Object} previous - The bundle which pre-dates the current bundle.
-* @return {String}
+ * @param {String} compression [null] - The compression level to compare, i.e 'gzip'.
+ * @return {String}
  */
-function getSizeDiff(current, previous) {
-	return ((current - previous) / 1024).toFixed(2);
+function getSizeDiff(current, previous, compression) {
+	compression = compression || 'raw';
+	const currentContentLength = current.sizes[compression];
+	const previousContentLength = previous.sizes[compression];
+	return ((currentContentLength - previousContentLength) / 1024).toFixed(2);
 }
 
 /**
@@ -20,8 +24,8 @@ function getSizeDiff(current, previous) {
  * @return {String}
  */
 function getBundleComparisonMessage(current, previous) {
-	const gzipDiff = getSizeDiff(current.sizes.gzip, previous.sizes.gzip);
-	const rawDiff = getSizeDiff(current.sizes.raw, previous.sizes.raw);
+	const rawDiff = getSizeDiff(current, previous);
+	const gzipDiff = getSizeDiff(current, previous, 'gzip');
 
 	// Use the current brand in the key in case the previous version is unbranded,
 	// but the current version has just added brand support.
@@ -57,7 +61,7 @@ module.exports = (fromBundles, toBundles) => {
 
 	// Message if no bundle sizes have changes at all.
 	const unequalComparisons = bundleComparisons.filter(c => {
-		const rawDiff = getSizeDiff(c.current.sizes.raw, c.previous.sizes.raw);
+		const rawDiff = getSizeDiff(c.current, c.previous);
 		return Math.abs(rawDiff) !== 0;
 	});
 
@@ -67,7 +71,7 @@ module.exports = (fromBundles, toBundles) => {
 
 	// Message if only small bundle size differences, which are not significant.
 	const significantComparisons = bundleComparisons.filter(c => {
-		const rawDiff = getSizeDiff(c.current.sizes.raw, c.previous.sizes.raw);
+		const rawDiff = getSizeDiff(c.current, c.previous);
 		return Math.abs(rawDiff) > threshold;
 	});
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ class OrigamiBundleSizeCliCommand extends Command {
 			toBundles = await fetchBundleSize(to);
 			fromBundles = await fetchBundleSize(from);
 		} catch (error) {
-			this.error(`Could notget bundle sizes: ${error.message}`);
+			this.error(`Could not get bundle sizes: ${error.message}`);
 		}
 
 		// Log message for CSS bundle size diff.

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -36,6 +36,6 @@ describe('origami-bundle-size-cli', () => {
 		// stop mocking stdout
 		stdout.stop();
 		// confirm the message we expect was output
-		proclaim.include(stdout.output, 'No bundle size difference found');
+		proclaim.include(stdout.output, 'No bundle size differences found.');
 	});
 });

--- a/test/unit/get-message.test.js
+++ b/test/unit/get-message.test.js
@@ -33,14 +33,44 @@ describe('get-message', () => {
 		sizes: { raw: '20000', gzip: '2000' }
 	}];
 
-	it('shows the bundle size difference for bundles which are larger', () => {
+	it('contains the bundle size difference for bundles which are larger', () => {
 		const message = getMessage(bundlesA, bundlesB);
 		proclaim.equal(message, 'css, master: 9.77kb increase (0.98kb/gzip)\ncss, internal: 9.69kb increase (0.49kb/gzip)\njs, master: 9.77kb increase (0.98kb/gzip)');
 	});
 
-	it('shows the bundle size difference for bundles which are smaller', () => {
+	it('contains the bundle size difference for bundles which are smaller', () => {
 		const message = getMessage(bundlesB, bundlesA);
 		proclaim.equal(message, 'css, master: 9.77kb decrease (-0.98kb/gzip)\ncss, internal: 9.69kb decrease (-0.49kb/gzip)\njs, master: 9.77kb decrease (-0.98kb/gzip)');
+	});
+
+	it('contains a simple message when all bundle sizes are equal', () => {
+		const message = getMessage(bundlesA, bundlesA);
+		proclaim.equal(message, 'No bundle size differences found.');
+	});
+
+	it('contains a simple message when all bundles are insignificantly different', () => {
+		// increase bundle size insignificant
+		const similarBundles = bundlesA.map(b => {
+			const clone = JSON.parse(JSON.stringify(b));
+			clone.sizes.raw = (new Number(clone.sizes.raw) + 200).toString();
+			return clone;
+		});
+		const message = getMessage(bundlesA, similarBundles);
+		proclaim.equal(message, 'No significant bundle size differences found.');
+	});
+
+	it('contains the bundle size difference for any significantly difference and a brief not of insignificantly differences', () => {
+		// increase bundle size insignificant
+		const similarBundles = bundlesA.map(b => {
+			const clone = JSON.parse(JSON.stringify(b));
+			clone.sizes.raw = (new Number(clone.sizes.raw) + 200).toString();
+			return clone;
+		});
+		// increase first bundle by a not-insignificant amount
+		similarBundles[0].sizes.raw = (new Number(similarBundles[0].sizes.raw) + 500).toString();
+		// confirm message
+		const message = getMessage(bundlesA, similarBundles);
+		proclaim.equal(message, 'css, master: 0.68kb increase (0.00kb/gzip)\nAn insignificant difference was found for: css (internal), js (master)');
 	});
 
 });

--- a/test/unit/get-message.test.js
+++ b/test/unit/get-message.test.js
@@ -70,7 +70,7 @@ describe('get-message', () => {
 		similarBundles[0].sizes.raw = (new Number(similarBundles[0].sizes.raw) + 500).toString();
 		// confirm message
 		const message = getMessage(bundlesA, similarBundles);
-		proclaim.equal(message, 'css, master: 0.68kb increase (0.00kb/gzip)\nAn insignificant difference was found for: css (internal), js (master)');
+		proclaim.equal(message, 'css, master: 0.68kb increase (0.00kb/gzip)\nAn insignificant difference was also found for: css (internal), js (master)');
 	});
 
 });


### PR DESCRIPTION
The threshold has changed from 0.5kb to 0.2kb (with no compression).

Before if there were no significant changes the following was output:
>No bundle size differences found.

Now if there are insignficant changes the following is output:
>No significant bundle size differences found.

If there are significant and insignificant bundle size changes, both
are output. E.g:
>css, master: 0.68kb increase (0.01kb/gzip)
>An insignificant difference was also found for: css (internal), js (master)