### PR TITLE
When testing bundles are expected, allow 10% variance on size.

### DIFF
--- a/test/integration/build-service-bundle-size.test.js
+++ b/test/integration/build-service-bundle-size.test.js
@@ -63,8 +63,56 @@ describe('build-service-bundle-size', () => {
 
 	for (const data of testData) {
 		it(`gets bundle information for ${data.language}${data.brands ? ` of brands ${data.brands.join(',')}` : ''} `, async () => {
+			// We can't reliably do a deep equal as the bundle sizes from
+			// the Origami Build Service may vary slightly over time. Instead
+			// find a matching bundle based on url and check properties
+			// individually. Allow a tolerance of 10% in the sizes assertion.
 			const bundles = await getBundleInfo('o-test-component', 'v1.0.30', data.language, data.brands || []);
-			proclaim.deepEqual(bundles, data.expected);
+			const expectedBundles = data.expected;
+			// Confirm bundle count.
+			proclaim.equal(
+				bundles.length,
+				expectedBundles.length,
+				`Returned ${bundles.length} bundles but was expecting ` +
+				`${expectedBundles.length}.`
+			);
+			for (const bundle of bundles) {
+				// Confirm bundle urls.
+				const expectedBundle = expectedBundles.find(
+					b => b.url === bundle.url
+				);
+				proclaim.ok(
+					expectedBundle,
+					`A bundle with url ${bundle.url} was not expected.`
+				);
+
+				// Compare the sizes of the bundle. We want to allow a tolerance
+				// when comparing these as the value may change slightly over
+				// time.
+				for (const key in bundle.sizes) {
+					const tolerance = 0.1; // 10%
+					const sizeValue = bundle.sizes[key];
+					const expectedSizeValue = expectedBundle.sizes[key];
+					const expectedMax = expectedSizeValue * (1 + tolerance);
+					const expectedMin = expectedSizeValue * (1 - tolerance);
+					const message = `The ${key} bundle should have a size ` +
+						`around "${expectedSizeValue}" but found "${sizeValue}".`;
+					proclaim.lessThanOrEqual(sizeValue, expectedMax, message);
+					proclaim.greaterThanOrEqual(sizeValue, expectedMin, message);
+				}
+
+				// Remove the bundle sizes, which have already been tested
+				// with a tolerance. And test the other bundle properties
+				// equal.
+				delete bundle.sizes;
+				delete expectedBundle.sizes;
+				proclaim.deepEqual(
+					bundle,
+					expectedBundle,
+					`A bundle with url ${bundle.url} did not have the ` +
+					`expected properties.`
+				);
+			}
 		});
 	}
 });

--- a/test/integration/build-service-bundle-size.test.js
+++ b/test/integration/build-service-bundle-size.test.js
@@ -90,15 +90,17 @@ describe('build-service-bundle-size', () => {
 				// when comparing these as the value may change slightly over
 				// time.
 				for (const key in bundle.sizes) {
-					const tolerance = 0.1; // 10%
-					const sizeValue = bundle.sizes[key];
-					const expectedSizeValue = expectedBundle.sizes[key];
-					const expectedMax = expectedSizeValue * (1 + tolerance);
-					const expectedMin = expectedSizeValue * (1 - tolerance);
-					const message = `The ${key} bundle should have a size ` +
-						`around "${expectedSizeValue}" but found "${sizeValue}".`;
-					proclaim.lessThanOrEqual(sizeValue, expectedMax, message);
-					proclaim.greaterThanOrEqual(sizeValue, expectedMin, message);
+					if (bundle.sizes.hasOwnProperty(key)) {
+						const tolerance = 0.1; // 10%
+						const sizeValue = bundle.sizes[key];
+						const expectedSizeValue = expectedBundle.sizes[key];
+						const expectedMax = expectedSizeValue * (1 + tolerance);
+						const expectedMin = expectedSizeValue * (1 - tolerance);
+						const message = `The ${key} bundle should have a size ` +
+							`around "${expectedSizeValue}" but found "${sizeValue}".`;
+						proclaim.lessThanOrEqual(sizeValue, expectedMax, message);
+						proclaim.greaterThanOrEqual(sizeValue, expectedMin, message);
+					}
 				}
 
 				// Remove the bundle sizes, which have already been tested
@@ -110,7 +112,7 @@ describe('build-service-bundle-size', () => {
 					bundle,
 					expectedBundle,
 					`A bundle with url ${bundle.url} did not have the ` +
-					`expected properties.`
+					'expected properties.'
 				);
 			}
 		});


### PR DESCRIPTION
We can't reliably do a deep equal as the bundle sizes from the
Origami Build Service may vary slightly over time. Instead find
a matching bundle based on url and check properties individually.
Allow a tolerance of 10% in the sizes assertion.

E.g. if the size increases dramatically we should error
<img width="1009" alt="Screenshot 2020-03-18 at 10 52 32" src="https://user-images.githubusercontent.com/10405691/76953498-b3791a80-6906-11ea-9930-30ede91b5a0b.png">
