### PR TITLE
Add ability to publish prereleases with a different dist-tag.

### DIFF
--- a/.github/workflows/automatic-tag-and-release.yml
+++ b/.github/workflows/automatic-tag-and-release.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }} # Checkout the merged commit
           fetch-depth: 0
+          token: ${{ secrets.ORIGAMI_VERSION_TOKEN }}
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # Get all tags from the origin
         if: github.event.pull_request.merged # Only run on merged pull-requests
       - uses: Financial-Times/origami-version@v1.2.0

--- a/.github/workflows/publish-to-npm-as-latest.yml
+++ b/.github/workflows/publish-to-npm-as-latest.yml
@@ -1,9 +1,10 @@
-name: Publish to npm
+name: Publish to npm as latest version
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+' # non-prerelease tag
 jobs:
-  publish:
+  publish-latest:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish-to-npm-as-prerelease.yml
+++ b/.github/workflows/publish-to-npm-as-prerelease.yml
@@ -1,0 +1,22 @@
+name: Publish to npm as prerelease version
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-*' # prerelease tag
+jobs:
+  publish-prerelease:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm ci
+    - name: Get the version
+      id: version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+    - run: npm version --no-git-tag-version ${{ steps.version.outputs.VERSION }}
+    - run: npm publish --tag prerelease
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Prior to this change, every release would be given the dist-tag `latest`, which is not what we want. We only want stable releases to be given the `latest` dist-tag.